### PR TITLE
Remove extra exclamation mark

### DIFF
--- a/src/main/kotlin/me/iru/commands/cRegister.kt
+++ b/src/main/kotlin/me/iru/commands/cRegister.kt
@@ -23,7 +23,7 @@ class cRegister(override var name: String = "register") : ICommand {
         if (sender is Player) {
             val p: Player = sender
             if (!loginProcess.contains(p)) {
-                p.sendMessage("${translations.getPrefix(PrefixType.ERROR)} ${translations.get("already_authed")}!")
+                p.sendMessage("${translations.getPrefix(PrefixType.ERROR)} ${translations.get("already_authed")}")
                 return true
             }
             val requirePin = authy.config.getBoolean("requirePin")


### PR DESCRIPTION
The locales already have an exclamation mark for `already_authed`; fixes double exclamation mark upon trying to run `/register` while already being logged in/registered.

Related:
https://github.com/Iru21/Authy/blob/f47034567b79addf91334cc1ffa29f1ecb427ead/src/main/kotlin/me/iru/commands/cLogin.kt#L28